### PR TITLE
Use Options from rom-support

### DIFF
--- a/lib/rom/http/dataset.rb
+++ b/lib/rom/http/dataset.rb
@@ -3,8 +3,14 @@ module ROM
     class Dataset
       include Enumerable
       include Equalizer.new(:config, :options)
+      include ROM::Options
 
-      attr_reader :config, :options
+      attr_reader :config
+
+      option :request_method, type: ::Symbol, default: :get, reader: true
+      option :path, type: ::String, default: ''
+      option :params, type: ::Hash, default: {}, reader: true
+      option :headers, type: ::Hash, default: {}
 
       class << self
         def default_request_handler(handler = Undefined)
@@ -20,11 +26,7 @@ module ROM
 
       def initialize(config, options = {})
         @config = config
-        @options = {
-          request_method: :get,
-          path: '',
-          params: {}
-        }.merge(options)
+        super(options)
       end
 
       def uri
@@ -47,16 +49,8 @@ module ROM
         '/' + path
       end
 
-      def request_method
-        options[:request_method]
-      end
-
-      def params
-        options[:params]
-      end
-
       def with_headers(headers)
-        self.class.new(config, options.merge(headers: headers))
+        __new__(config, options.merge(headers: headers))
       end
 
       def add_header(header, value)
@@ -64,7 +58,7 @@ module ROM
       end
 
       def with_options(opts)
-        self.class.new(config, options.merge(opts))
+        __new__(config, options.merge(opts))
       end
 
       def with_path(path)
@@ -132,6 +126,10 @@ module ROM
 
       def default_request_handler
         self.class.default_request_handler
+      end
+
+      def __new__(*args, &block)
+        self.class.new(*args, &block)
       end
     end
   end

--- a/spec/shared/command_behaviour.rb
+++ b/spec/shared/command_behaviour.rb
@@ -1,10 +1,10 @@
 shared_examples_for 'a command' do
   describe '#method_missing' do
     it 'forwards to relation and wraps response if it returned another relation' do
-      new_command = command.with_params(1)
+      new_command = command.with_params({})
 
       expect(new_command).to be_instance_of(command.class)
-      expect(new_command.relation).to eq(command.with_params(1).relation)
+      expect(new_command.relation).to eq(command.with_params({}).relation)
     end
 
     it 'returns original response if it was not a relation' do

--- a/spec/unit/rom/http/dataset_spec.rb
+++ b/spec/unit/rom/http/dataset_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe ROM::HTTP::Dataset do
           is_expected.to eq(
             request_method: :get,
             path: '',
-            params: {}
+            params: {},
+            headers: {}
           )
         end
       end
@@ -329,7 +330,8 @@ RSpec.describe ROM::HTTP::Dataset do
         path: '',
         params: {
           name: name
-        }
+        },
+        headers: {}
       )
     end
     it { is_expected.to_not be(dataset) }


### PR DESCRIPTION
Using `Options` from `rom-support` should make for a nicer interface when extending `ROM::HTTP`

```ruby
module ROM
  module MyAdapter
    class Dataset < ROM::HTTP::Dataset
      option :my_option, type: ::Hash, default: {}, reader: true
    end
  end
end
```