### PR TITLE
Replace ROM::Options with dry-initializer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 bundler_args: --without sql benchmarks console tools
 script: "bundle exec rake ci"
 rvm:
-  - 2.1
   - 2.2
   - 2.3.1
   - rbx-3

--- a/lib/rom/http/relation.rb
+++ b/lib/rom/http/relation.rb
@@ -1,4 +1,5 @@
 require 'dry/core/cache'
+require 'rom/initializer'
 require 'rom/plugins/relation/key_inference'
 require 'rom/http/transformer'
 
@@ -8,13 +9,14 @@ module ROM
     #
     class Relation < ROM::Relation
       extend Dry::Core::Cache
+      extend ::ROM::Initializer
       include Enumerable
 
       adapter :http
 
       use :key_inference
 
-      option :transformer, reader: true, default: ::ROM::HTTP::Transformer
+      option :transformer, reader: true, default: proc { ::ROM::HTTP::Transformer }
 
       forward :with_request_method, :with_path, :append_path, :with_options,
               :with_params, :clear_params

--- a/rom-http.gemspec
+++ b/rom-http.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec', '~> 3.1'
+  spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/spec/integration/abstract/relation_spec.rb
+++ b/spec/integration/abstract/relation_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe ROM::HTTP::Relation do
         response_handler: response_handler,
         name: :users
       },
-      request_method: :get,
-      path: "/#{id}",
+      path: "users/#{id}",
       params: params
     )
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'bundler'
 Bundler.setup
 
 require 'rom-http'
+require 'rspec/its'
 
 begin
 require 'byebug'

--- a/spec/unit/rom/http/dataset_spec.rb
+++ b/spec/unit/rom/http/dataset_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe ROM::HTTP::Dataset do
       it { is_expected.to eq(config) }
     end
 
-    describe '#options' do
-      subject { dataset.options }
+    describe 'options' do
+      subject { dataset }
 
       context 'with options passed' do
         let(:options) do
@@ -35,29 +35,19 @@ RSpec.describe ROM::HTTP::Dataset do
           }
         end
 
-        it do
-          is_expected.to eq(
-            base_path: '',
-            request_method: :put,
-            path: '',
-            params: {},
-            headers: {
-              'Accept' => 'application/json'
-            }
-          )
-        end
+        its(:base_path) { is_expected.to eq('') }
+        its(:request_method) { is_expected.to eq(:put) }
+        its(:path) { is_expected.to eq('') }
+        its(:params) { is_expected.to eq({}) }
+        its(:headers) { is_expected.to eq('Accept' => 'application/json') }
       end
 
       context 'with no options passed' do
-        it do
-          is_expected.to eq(
-            base_path: '',
-            request_method: :get,
-            path: '',
-            params: {},
-            headers: {}
-          )
-        end
+        its(:base_path) { is_expected.to eq('') }
+        its(:request_method) { is_expected.to eq(:get) }
+        its(:path) { is_expected.to eq('') }
+        its(:params) { is_expected.to eq({}) }
+        its(:headers) { is_expected.to eq({}) }
       end
     end
   end
@@ -316,16 +306,13 @@ RSpec.describe ROM::HTTP::Dataset do
 
     subject! { new_dataset }
 
-    it { expect(new_dataset.config).to eq(config) }
-    it do
-      expect(new_dataset.options).to eq(
-        base_path: '',
-        request_method: :get,
-        path: '',
-        params: {},
-        headers: headers
-      )
-    end
+    its(:config) { is_expected.to eq(config) }
+    its(:base_path) { is_expected.to eq('') }
+    its(:request_method) { is_expected.to eq(:get) }
+    its(:path) { is_expected.to eq('') }
+    its(:params) { is_expected.to eq({}) }
+    its(:headers) { is_expected.to eq(headers) }
+
     it { is_expected.to_not be(dataset) }
     it { is_expected.to be_a(ROM::HTTP::Dataset) }
   end
@@ -371,18 +358,13 @@ RSpec.describe ROM::HTTP::Dataset do
 
     subject! { new_dataset }
 
-    it { expect(new_dataset.config).to eq(config) }
-    it do
-      expect(new_dataset.options).to eq(
-        base_path: '',
-        request_method: :get,
-        path: '',
-        params: {
-          name: name
-        },
-        headers: {}
-      )
-    end
+    its(:config) { is_expected.to eq(config) }
+    its(:base_path) { is_expected.to eq('') }
+    its(:request_method) { is_expected.to eq(:get) }
+    its(:path) { is_expected.to eq('') }
+    its(:params) { is_expected.to eq(name: name) }
+    its(:headers) { is_expected.to eq({}) }
+
     it { is_expected.to_not be(dataset) }
     it { is_expected.to be_a(ROM::HTTP::Dataset) }
   end


### PR DESCRIPTION
* Latest master of `rom` breaking `rom-http` due to migration to `dry-initializer`
* Dropping ruby 2.1 support due to `dry-initializer`