### PR TITLE
Flatten result of Create#execute

### DIFF
--- a/lib/rom/http/commands/create.rb
+++ b/lib/rom/http/commands/create.rb
@@ -11,10 +11,10 @@ module ROM
         #
         # @api public
         def execute(tuples)
-          Array([tuples]).flatten.map do |tuple|
+          Array([tuples]).flatten(1).map do |tuple|
             attributes = input[tuple]
             relation.insert(attributes.to_h)
-          end.to_a
+          end.flatten(1)
         end
       end
     end

--- a/spec/integration/abstract/commands/create_spec.rb
+++ b/spec/integration/abstract/commands/create_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ROM::HTTP::Commands::Create do
       configuration.register_command(command)
 
       allow(request_handler).to receive(:call).and_return(response)
-      allow(response_handler).to receive(:call).and_return(tuple)
+      allow(response_handler).to receive(:call).and_return([tuple])
     end
 
     subject! { container.command(:users).create.call(attributes) }


### PR DESCRIPTION
**Description:**
`relation.insert` always return array as we do `Array([JSON.parse(response.body, symbolize_names: true)]).flatten` in `ResponseHandler#call`

This is why `Command::Create#execute` results in something like: `[[{id: 1, foo: 'bar'}]]`.

This behaviour brakes command composition and rom-sql associations

**Example:**

```ruby
require 'bundler/inline'
require 'json'

gemfile(true) do
  source 'https://rubygems.org'
  gem 'rom', github: 'rom-rb/rom'
  gem 'rom-sql', github: 'rom-rb/rom-sql'
  gem 'rom-http', github: 'rom-rb/rom-http'
  gem 'sqlite3'
end

class RequestHandler
  def call(dataset)
    { id: '0032C000007NbpbQAC' }.to_json
  end
end

class ResponseHandler
  def call(response, dataset)
    Array([JSON.parse(response, symbolize_names: true)]).flatten
  end
end

config = ROM::Configuration.new(
  default: [:sql, 'sqlite::memory'],
  http: [:http,
    uri: 'https://foo.com',
    headers: {
      Accept: 'application/json'
    },
    request_handler: RequestHandler.new,
    response_handler: ResponseHandler.new
  ]
)

gateway = config.gateways[:default]
migrations = []

migrations << gateway.migration do
  change do
    create_table :users do
      primary_key :id
      column :contact_id, String, null: false, unique: true
    end
  end
end

migrations.each do |migration|
  migration.apply(gateway.connection, :up)
end

class Users < ROM::Relation[:sql]
  schema(infer: true) do
    associations do
      belongs_to :contact
    end
  end
end

class Contacts < ROM::Relation[:http]
  gateway :http

  schema do
    attribute :id, ROM::Types::Strict::String.meta(primary_key: true)
  end
end

module Commands
  class CreateUser < ROM::Commands::Create[:sql]
    relation :users
    register_as :create
    result :one

    associates :contact, key: [:contact_id, :id]
  end

  class CreateContact < ROM::Commands::Create[:http]
    relation :contacts
    register_as :create
    result :one
  end
end


config.register_relation(Users)
config.register_relation(Contacts)
config.register_command(Commands::CreateUser)
config.register_command(Commands::CreateContact)

env = ROM.container(config)

command = env.command([
  { contact: :contacts }, [:create, [{ user: :users }, [:create]]]
])
command.call(contact: { foo: 'bar', user: {} })
# /Users/simpleman/code/rom-http/vendor/ruby/2.3.0/bundler/gems/rom-604baf6c8633/lib/rom/commands/graph/input_evaluator.rb:45:in `call':
# undefined method `at' for {:foo=>"bar", :user=>{}}:Hash (NoMethodError)
```