### PR TITLE
WIP: Add base_path param for relation

### DIFF
--- a/lib/rom/http/dataset.rb
+++ b/lib/rom/http/dataset.rb
@@ -83,7 +83,7 @@ module ROM
       #
       # @api public
       def base_path
-        STRIP_PATH.call(super)
+        STRIP_PATH.call(config[:base_path] || super)
       end
 
       # Return the dataset path

--- a/lib/rom/http/gateway.rb
+++ b/lib/rom/http/gateway.rb
@@ -51,9 +51,9 @@ module ROM
       # @return [Dataset]
       #
       # @api public
-      def dataset(name)
+      def dataset(name, config_options)
         dataset_klass = namespace.const_defined?(:Dataset) ? namespace.const_get(:Dataset) : Dataset
-        datasets[name] = dataset_klass.new(config.merge(name: name))
+        datasets[name] = dataset_klass.new(config.merge(name: name).merge(config_options))
       end
 
       # Check if dataset exists

--- a/lib/rom/http/relation.rb
+++ b/lib/rom/http/relation.rb
@@ -18,9 +18,19 @@ module ROM
 
       option :transformer, reader: true, default: proc { ::ROM::HTTP::Transformer }
 
+      defines :base_path
+
       forward :with_request_method, :with_path, :append_path, :with_options,
               :with_params, :clear_params
 
+
+      class << self
+        def dataset_options
+          @dataset_options ||= {
+            base_path: base_path
+          }
+        end
+      end
 
       def initialize(*)
         super


### PR DESCRIPTION
**Why?**
Currently there is no way to redefine commands base_path without
overriding them completely. And it also would nice to have
ability to define base_path on relation level.

**This PR**
Adds `base_path` as relation macro that will be used as base path
to read data and for create/update/destroy commands.

Example:
```ruby
class Contacts < ROM::Relation[:http]
  gateway :http
  base_path '/my/custom/path'
end
```

**Depends**
- https://github.com/rom-rb/rom/pull/378