### PR TITLE
Transform keys on insert and update

### DIFF
--- a/spec/integration/abstract/commands/create_spec.rb
+++ b/spec/integration/abstract/commands/create_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe ROM::HTTP::Commands::Create do
     Class.new(ROM::HTTP::Relation) do
       schema(:users) do
         attribute :id, ROM::Types::Int
+        attribute :first_name, ROM::Types::String
+        attribute :last_name, ROM::Types::String
       end
 
       def by_id(id)
@@ -14,8 +16,8 @@ RSpec.describe ROM::HTTP::Commands::Create do
 
   context 'with single tuple' do
     let(:response) { double }
-    let(:tuple) { double }
     let(:attributes) { { first_name: 'John', last_name: 'Jackson' } }
+    let(:tuple) { attributes.merge(id: 1) }
     let(:command) do
       Class.new(ROM::HTTP::Commands::Create) do
         register_as :create
@@ -57,10 +59,10 @@ RSpec.describe ROM::HTTP::Commands::Create do
   context 'with a collection' do
     let(:response_1) { double }
     let(:response_2) { double }
-    let(:tuple_1) { double }
-    let(:tuple_2) { double }
     let(:attributes_1) { { first_name: 'John', last_name: 'Jackson' } }
     let(:attributes_2) { { first_name: 'Jill', last_name: 'Smith' } }
+    let(:tuple_1) { attributes_1.merge(id: 1) }
+    let(:tuple_2) { attributes_2.merge(id: 2) }
     let(:attributes) { [attributes_1, attributes_2] }
     let(:command) do
       Class.new(ROM::HTTP::Commands::Create) do

--- a/spec/integration/abstract/commands/update_spec.rb
+++ b/spec/integration/abstract/commands/update_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe ROM::HTTP::Commands::Update do
     Class.new(ROM::HTTP::Relation) do
       schema(:users) do
         attribute :id, ROM::Types::Int
+        attribute :first_name, ROM::Types::String
+        attribute :last_name, ROM::Types::String
       end
 
       def by_id(id)
@@ -14,8 +16,8 @@ RSpec.describe ROM::HTTP::Commands::Update do
 
   context 'with single tuple' do
     let(:response) { double }
-    let(:tuple) { double }
     let(:attributes) { { first_name: 'John', last_name: 'Jackson' } }
+    let(:tuple) { attributes.merge(id: 1) }
     let(:command) do
       Class.new(ROM::HTTP::Commands::Update) do
         register_as :update
@@ -57,10 +59,10 @@ RSpec.describe ROM::HTTP::Commands::Update do
   context 'with a collection' do
     let(:response_1) { double }
     let(:response_2) { double }
-    let(:tuple_1) { double }
-    let(:tuple_2) { double }
     let(:attributes_1) { { first_name: 'John', last_name: 'Jackson' } }
     let(:attributes_2) { { first_name: 'Jill', last_name: 'Smith' } }
+    let(:tuple_1) { attributes_1.merge(id: 1) }
+    let(:tuple_2) { attributes_2.merge(id: 2) }
     let(:attributes) { [attributes_1, attributes_2] }
     let(:command) do
       Class.new(ROM::HTTP::Commands::Update) do


### PR DESCRIPTION
**Why?**
If we are using `rom-http` with `rom-sql` associate and have key
renaming, associate will blow up trying to find primary_key in tuple
as Relation#primary_key returns renamed key name but tuple has original

Look into source here:
https://github.com/rom-rb/rom-sql/blob/master/lib/rom/sql/association/many_to_one.rb#L51

**This PR**
Adding transformation to Relation#insert and Relation#update