### PR TITLE
Upgrade rom to ~> 5.0

### DIFF
--- a/rom-http.gemspec
+++ b/rom-http.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby'
   spec.add_runtime_dependency 'addressable'
-  spec.add_runtime_dependency 'rom', '~> 4.0'
+  spec.add_runtime_dependency 'rom', '~> 5.0'
   spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.3'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.6'


### PR DESCRIPTION
With the rom 5.0 release, we now can't use any version of rom-http with it: which this change would solve.