### PR TITLE
Default handlers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ group :test do
     gem 'rom-repository', group: :tools
   end
 
-  gem 'faraday'
+  gem 'webmock'
+  gem 'vcr'
   gem 'simplecov', platforms: :mri
 end
 

--- a/lib/rom/http/handlers.rb
+++ b/lib/rom/http/handlers.rb
@@ -1,0 +1,14 @@
+require 'rom/http/handlers/json'
+
+module ROM
+  module HTTP
+    # Request/response handler registry
+    #
+    # @api public
+    class Handlers
+      extend Dry::Container::Mixin
+
+      register(:json, request: JSONRequest, response: JSONResponse)
+    end
+  end
+end

--- a/lib/rom/http/handlers/json.rb
+++ b/lib/rom/http/handlers/json.rb
@@ -11,7 +11,7 @@ module ROM
     # Default request/response handlers
     #
     # @api public
-    module Handlers
+    class Handlers
       # Default handler for JSON requests
       #
       # @api public

--- a/lib/rom/http/handlers/json.rb
+++ b/lib/rom/http/handlers/json.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'uri'
+require 'net/http'
+require 'json'
+
+require 'rom/support/inflector'
+
+module ROM
+  module HTTP
+    # Default request/response handlers
+    #
+    # @api public
+    module Handlers
+      # Default handler for JSON requests
+      #
+      # @api public
+      class JSONRequest
+        # Handle JSON request for the provided dataset
+        #
+        # @param [Dataset] dataset
+        #
+        # @return [Array<Hash>]
+        #
+        # @api public
+        def self.call(dataset)
+          uri = URI(dataset.uri)
+
+          uri.path = dataset.absolute_path
+          uri.query = URI.encode_www_form(dataset.params)
+
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true if uri.scheme.eql?('https')
+
+          request_class = Net::HTTP.const_get(ROM::Inflector.classify(dataset.request_method))
+
+          request = request_class.new(uri.request_uri)
+
+          dataset.headers.each_with_object(request) do |(header, value), request|
+            request[header.to_s] = value
+          end
+
+          http.request(request)
+        end
+      end
+
+      # Default handler for JSON responses
+      #
+      # @api public
+      class JSONResponse
+        # Handle JSON responses
+        #
+        # @param [Net::HTTP::Response] response
+        # @param [Dataset] dataset
+        #
+        # @return [Array<Hash>]
+        #
+        # @api public
+        def self.call(response, dataset)
+          Array([JSON.parse(response.body)]).flatten(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/github_repos.yml
+++ b/spec/fixtures/vcr_cassettes/github_repos.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/orgs/rom-rb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 29 Apr 2019 10:05:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '57'
+      X-Ratelimit-Reset:
+      - '1556535839'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - W/"7c4febf9df2293903c92f884a768a81a"
+      Last-Modified:
+      - Wed, 03 Apr 2019 14:36:48 GMT
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E967:457D:88BBB1:15715A9:5CC6CC52
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"rom-rb","id":4589832,"node_id":"MDEyOk9yZ2FuaXphdGlvbjQ1ODk4MzI=","url":"https://api.github.com/orgs/rom-rb","repos_url":"https://api.github.com/orgs/rom-rb/repos","events_url":"https://api.github.com/orgs/rom-rb/events","hooks_url":"https://api.github.com/orgs/rom-rb/hooks","issues_url":"https://api.github.com/orgs/rom-rb/issues","members_url":"https://api.github.com/orgs/rom-rb/members{/member}","public_members_url":"https://api.github.com/orgs/rom-rb/public_members{/member}","avatar_url":"https://avatars3.githubusercontent.com/u/4589832?v=4","description":"Persistence
+        and mapping toolkit for Ruby","name":"rom-rb","company":null,"blog":"http://rom-rb.org","location":"Planet
+        Earth","email":"","is_verified":false,"has_organization_projects":true,"has_repository_projects":true,"public_repos":32,"public_gists":0,"followers":0,"following":0,"html_url":"https://github.com/rom-rb","created_at":"2013-06-01T22:03:54Z","updated_at":"2019-04-03T14:36:48Z","type":"Organization"}'
+    http_version: 
+  recorded_at: Mon, 29 Apr 2019 10:05:06 GMT
+recorded_with: VCR 4.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,12 @@ begin
 require 'byebug'
 rescue LoadError; end
 
-root = Pathname(__FILE__).dirname
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "#{SPEC_ROOT}/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
 
 Dir[root.join('support/**/*.rb').to_s].each { |file| require file }
 Dir[root.join('shared/**/*.rb').to_s].each { |file| require file }

--- a/spec/unit/rom/http/gateway_spec.rb
+++ b/spec/unit/rom/http/gateway_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe ROM::HTTP::Gateway do
 
   describe '#dataset' do
     context 'when extended' do
-      subject(:gateway) { Test::Gateway.new(uri: 'test') }
+      subject(:gateway) { Test::Gateway.new(uri: 'test', **config) }
+
+      let(:config) { Hash.new }
 
       before do
         module Test
@@ -52,6 +54,24 @@ RSpec.describe ROM::HTTP::Gateway do
 
         it 'returns ROM::HTTP::Dataset' do
           expect(gateway.dataset(:test)).to be_instance_of(Test::Dataset)
+        end
+      end
+
+      context 'when handlers identifier is configured' do
+        let(:config) do
+          { handlers: :json }
+        end
+
+        let(:dataset) do
+          gateway.dataset(:test)
+        end
+
+        it 'sets registered request handler' do
+          expect(dataset.request_handler).to be(ROM::HTTP::Handlers[:json][:request])
+        end
+
+        it 'sets registered response handler' do
+          expect(dataset.response_handler).to be(ROM::HTTP::Handlers[:json][:response])
         end
       end
     end

--- a/spec/unit/rom/http/handlers/json_spec.rb
+++ b/spec/unit/rom/http/handlers/json_spec.rb
@@ -1,0 +1,26 @@
+require 'rom/http/handlers/json'
+
+RSpec.describe ROM::HTTP::Handlers do
+  describe 'JSON' do
+    subject(:dataset) do
+      ROM::HTTP::Dataset.new(
+        uri: uri,
+        request_handler: ROM::HTTP::Handlers::JSONRequest,
+        response_handler: ROM::HTTP::Handlers::JSONResponse
+      )
+    end
+
+    let(:uri) do
+      'https://api.github.com'
+    end
+
+    it 'loads an array with hashes from the response body' do
+      VCR.use_cassette(:github_repos) do
+        org = dataset.with_path('/orgs/rom-rb').first
+
+        expect(org['id']).to be(4589832)
+        expect(org['login']).to eql('rom-rb')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds default `JSON` request/response handlers. This should make getting started with this adapter much nicer. In addition to that, I added a way of registering your own handlers.

Here's an example:

``` ruby
# use built-in JSON handlers for all datasets
ROM::Configuration.new(:http, uri: "https://api.github.com", handlers: :json)

# register your own handlers
ROM::HTTP::Handlers.register(:my_handlers, request: MyRequestHandler, response: MyResponseHandler)

# voilà
ROM::Configuration.new(:http, uri: "https://api.github.com", handlers: :my_handlers)
```

Closes #17 