### PR TITLE
Patches Dataset and JSON handler:

### DIFF
--- a/lib/rom/http/dataset.rb
+++ b/lib/rom/http/dataset.rb
@@ -124,13 +124,11 @@ module ROM
       #
       # @api public
       def uri
-        uri = URI(join_path(super, path))
-
-        if get? && params.any?
-          uri.query = param_encoder.call(params)
+        URI(join_path(super, path)).tap do |uri|
+          if params.any?
+            uri.query = param_encoder.call(params)
+          end
         end
-
-        uri
       end
 
       # Return true if request method is set to :get

--- a/lib/rom/http/handlers/json.rb
+++ b/lib/rom/http/handlers/json.rb
@@ -26,9 +26,6 @@ module ROM
         def self.call(dataset)
           uri = URI(dataset.uri)
 
-          uri.path = dataset.absolute_path
-          uri.query = URI.encode_www_form(dataset.params)
-
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = true if uri.scheme.eql?('https')
 

--- a/spec/unit/rom/http/dataset_spec.rb
+++ b/spec/unit/rom/http/dataset_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe ROM::HTTP::Dataset do
             { uri: uri, request_method: :post, params: { username: 'John', role: 'admin' } }
           end
 
-          it 'returns a valid URI without a query' do
-            expect(dataset.uri).to eql(URI(uri))
+          it 'returns a valid URI with a query' do
+            expect(dataset.uri).to eql(URI("#{uri}?username=John&role=admin"))
           end
         end
       end


### PR DESCRIPTION
- Dataset#uri incorrectly omits params from non-GET requests.
- JSONRequest clobbers URI path (see
https://discourse.rom-rb.org/t/rom-http-gateway-and-dataset-uri-paths/407)
- JSONRequest redundantly sets URI query (and clobbers Dataset#param_encoder 
by hard-coding URI.www_encode_form)