### PR TITLE
Separate request params into query_params and body_params

### DIFF
--- a/lib/rom/http/handlers/json.rb
+++ b/lib/rom/http/handlers/json.rb
@@ -24,10 +24,7 @@ module ROM
         #
         # @api public
         def self.call(dataset)
-          uri = URI(dataset.uri)
-
-          uri.path = dataset.absolute_path
-          uri.query = URI.encode_www_form(dataset.params)
+          uri = dataset.uri
 
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = true if uri.scheme.eql?('https')
@@ -39,6 +36,8 @@ module ROM
           dataset.headers.each_with_object(request) do |(header, value), request|
             request[header.to_s] = value
           end
+
+          request.body = JSON.dump(dataset.body_params) if dataset.body_params.any?
 
           http.request(request)
         end

--- a/lib/rom/http/relation.rb
+++ b/lib/rom/http/relation.rb
@@ -24,7 +24,8 @@ module ROM
 
       forward :with_headers, :add_header, :with_options,
               :with_base_path, :with_path, :append_path,
-              :with_request_method, :with_params, :add_params
+              :with_request_method, :with_query_params, :add_query_params,
+              :with_body_params, :add_body_params
 
       def primary_key
         schema.primary_key_name

--- a/spec/integration/abstract/commands/create_spec.rb
+++ b/spec/integration/abstract/commands/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ROM::HTTP::Commands::Create do
       end
 
       def by_id(id)
-        with_params(id: id)
+        with_query_params(id: id)
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe ROM::HTTP::Commands::Create do
         response_handler: response_handler,
         base_path: :users,
         request_method: :post,
-        params: attributes
+        body_params: attributes
       )
     end
 
@@ -82,7 +82,7 @@ RSpec.describe ROM::HTTP::Commands::Create do
         response_handler: response_handler,
         base_path: :users,
         request_method: :post,
-        params: attributes_1
+        body_params: attributes_1
       )
     end
 
@@ -94,7 +94,7 @@ RSpec.describe ROM::HTTP::Commands::Create do
         response_handler: response_handler,
         base_path: :users,
         request_method: :post,
-        params: attributes_2
+        body_params: attributes_2
       )
     end
 

--- a/spec/integration/abstract/commands/update_spec.rb
+++ b/spec/integration/abstract/commands/update_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ROM::HTTP::Commands::Update do
       end
 
       def by_id(id)
-        with_params(id: id)
+        with_query_params(id: id)
       end
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe ROM::HTTP::Commands::Update do
         request_handler: request_handler,
         response_handler: response_handler,
         request_method: :put,
-        params: attributes
+        body_params: attributes
       )
     end
 
@@ -80,7 +80,7 @@ RSpec.describe ROM::HTTP::Commands::Update do
         response_handler: response_handler,
         base_path: :users,
         request_method: :put,
-        params: attributes_1
+        body_params: attributes_1
       )
     end
 
@@ -92,7 +92,7 @@ RSpec.describe ROM::HTTP::Commands::Update do
         response_handler: response_handler,
         base_path: :users,
         request_method: :put,
-        params: attributes_2
+        body_params: attributes_2
       )
     end
 

--- a/spec/integration/abstract/relation_spec.rb
+++ b/spec/integration/abstract/relation_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'rom-repository'
 
 RSpec.describe ROM::HTTP::Relation do
-  subject(:users) { container.relations[:users].by_id(id).filter(params) }
+  subject(:users) { container.relations[:users].by_id(id).filter(query_params) }
 
   include_context 'setup'
 
@@ -18,7 +18,7 @@ RSpec.describe ROM::HTTP::Relation do
       end
 
       def filter(params)
-        with_params(params)
+        with_query_params(params)
       end
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe ROM::HTTP::Relation do
   let(:response) { tuples.to_json }
   let(:tuples) { [{ 'id' => 1337, 'name' => 'John' }] }
   let(:id) { 1337 }
-  let(:params) { { filters: { first_name: 'John' } } }
+  let(:query_params) { { filters: { first_name: 'John' } } }
 
   let(:dataset) do
     ROM::HTTP::Dataset.new(
@@ -36,7 +36,7 @@ RSpec.describe ROM::HTTP::Relation do
       response_handler: response_handler,
       base_path: :users,
       path: "#{id}",
-      params: params
+      query_params: query_params
     )
   end
 
@@ -64,7 +64,7 @@ RSpec.describe ROM::HTTP::Relation do
     end
 
     it 'returns structs' do
-      user = repo.users.by_id(1337).filter(params).first
+      user = repo.users.by_id(1337).filter(query_params).first
 
       expect(user.id).to be(1337)
       expect(user.name).to eql('John')

--- a/spec/unit/rom/http/relation_spec.rb
+++ b/spec/unit/rom/http/relation_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ROM::HTTP::Relation do
 
   describe '#insert' do
     let(:result) do
-      relation.insert(name: 'John')
+      relation.insert(body_params: { name: 'John' })
     end
 
     context 'with single tuple' do
@@ -122,7 +122,7 @@ RSpec.describe ROM::HTTP::Relation do
 
   describe '#update' do
     let(:result) do
-      relation.update(name: 'John')
+      relation.update(body_params: { name: 'John' })
     end
 
     context 'with single tuple' do


### PR DESCRIPTION
Breaking change as it removes the old `params` option and renames `param_encoder` to `query_param_encoder`, see https://github.com/rom-rb/rom-http/pull/43 for details