### PR TITLE
lib/rom/http/dataset.rb:24:in `<module:HTTP>' [dry-configurable] defa…

### DIFF
--- a/lib/rom/http/dataset.rb
+++ b/lib/rom/http/dataset.rb
@@ -71,7 +71,7 @@ module ROM
       #
       #     MyDataset.query_param_encoder # MyParamEncoder
       #     MyDataset.new(uri: "http://localhost").query_param_encoder # MyParamEncoder
-      setting :query_param_encoder, URI.method(:encode_www_form), reader: true
+      setting :query_param_encoder, default: URI.method(:encode_www_form), reader: true
 
       # @!attribute [r] request_handler
       #   @return [Object]


### PR DESCRIPTION
…ult value as positional argument to settings is deprecated and will be removed in the next major version

Provide a `default:` keyword argument instead